### PR TITLE
Fix comments and add more operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "vscode": "^1.8.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "contributes": {
         "languages": [{

--- a/syntaxes/mcrl2.tmLanguage.json
+++ b/syntaxes/mcrl2.tmLanguage.json
@@ -34,7 +34,7 @@
 				},
 				{
 					"name": "keyword.operator.mcrl2",
-					"match": "\\b(<=|->|<>|==|!=|\\|>|<\\||in|#|\\.|\\+\\+|\\+|\\*|-|!|div|mod|hide|rename|allow|block|comm|delay|mu|nu|pbes|yaled)\\b"
+					"match": "(<=|->|<>|==|!=|\\|>|<\\||#|\\.|\\+\\+|\\+|\\*|-|!|&&|\\||=|\\b(in|div|mod|hide|rename|allow|block|comm|delay|mu|nu|pbes|yaled)\\b)"
 				}
 			]
 		},

--- a/syntaxes/mcrl2.tmLanguage.json
+++ b/syntaxes/mcrl2.tmLanguage.json
@@ -15,6 +15,9 @@
 			"include": "#strings"
 		},
 		{
+			"include": "#comments"
+		},
+		{
 			"include": "#entity"
 		}
 	],
@@ -73,8 +76,8 @@
 		"comments": {
 			"patterns": [
 				{
-					"name": "comment.line.percentage.mcrl2",
-					"match": "[^\\]?%.*$"
+					"name": "comment.line.percentage",
+					"match": "(?<!\\\\)(?:\\\\{2})*%.*$"
 				}
 			]
 		},


### PR DESCRIPTION
This pull request fixes:
- The comments issue
- Operators boundaries for non alfabetic operators like `==`, `<|`, `<=`...

Adds:
- Operator recognision of `&&`, `|` and `=`